### PR TITLE
Add missing overloads

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,9 +54,6 @@ import {ParseLatin} from 'parse-latin'
  *     should be retext plugins
  *
  * @overload
- * @returns {TransformMutate}
- *
- * @overload
  * @param {Processor} processor
  * @param {Options | null | undefined} [options]
  * @returns {TransformBridge}
@@ -67,14 +64,14 @@ import {ParseLatin} from 'parse-latin'
  * @returns {TransformMutate}
  *
  * @overload
- * @param {Parser | Processor} [destination]
+ * @param {Parser | Processor} destination
  *   Parser or processor (required).
  * @param {Options | null | undefined} [options]
  *   Configuration (optional).
  * @returns {TransformBridge | TransformMutate}
  *   Transform.
  *
- * @param {Parser | Processor} [destination]
+ * @param {Parser | Processor} destination
  *   Parser or processor (required).
  * @param {Options | null | undefined} [options]
  *   Configuration (optional).

--- a/lib/index.js
+++ b/lib/index.js
@@ -54,6 +54,9 @@ import {ParseLatin} from 'parse-latin'
  *     should be retext plugins
  *
  * @overload
+ * @returns {TransformMutate}
+ *
+ * @overload
  * @param {Processor} processor
  * @param {Options | null | undefined} [options]
  * @returns {TransformBridge}
@@ -63,7 +66,15 @@ import {ParseLatin} from 'parse-latin'
  * @param {Options | null | undefined} [options]
  * @returns {TransformMutate}
  *
- * @param {Parser | Processor} destination
+ * @overload
+ * @param {Parser | Processor} [destination]
+ *   Parser or processor (required).
+ * @param {Options | null | undefined} [options]
+ *   Configuration (optional).
+ * @returns {TransformBridge | TransformMutate}
+ *   Transform.
+ *
+ * @param {Parser | Processor} [destination]
  *   Parser or processor (required).
  * @param {Options | null | undefined} [options]
  *   Configuration (optional).

--- a/test.js
+++ b/test.js
@@ -17,7 +17,6 @@ test('remarkRetext', async function (t) {
 
   await t.test('should throw when w/o parser or processor', async function () {
     assert.throws(function () {
-      // @ts-expect-error: check how missing options is handled.
       unified().use(remarkRetext).freeze()
     }, /Expected `parser` \(such as from `parse-english`\) or `processor` \(a unified pipeline\) as `destination`/)
   })
@@ -35,7 +34,6 @@ test('remarkRetext', async function (t) {
   await t.test('should bridge', async function () {
     const file = await unified()
       .use(remarkParse)
-      // @ts-expect-error: TS barfs on overloads that result in bridges.
       .use(remarkRetext, unified().use(retextEnglish))
       .use(remarkStringify)
       .process('## Hello, world! ##')

--- a/test.js
+++ b/test.js
@@ -17,6 +17,7 @@ test('remarkRetext', async function (t) {
 
   await t.test('should throw when w/o parser or processor', async function () {
     assert.throws(function () {
+      // @ts-expect-error: check how missing options is handled.
       unified().use(remarkRetext).freeze()
     }, /Expected `parser` \(such as from `parse-english`\) or `processor` \(a unified pipeline\) as `destination`/)
   })


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Aremarkjs&type=issues and https://github.com/orgs/remarkjs/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This PR adds two more overloads to the `remarkRetext` function to fix the TypeScript type definitions (see issue #18). One without any parameters and another with a common signature (as the compiler doesn't generate one without the `@overload` tag).

**New overloads:**
```js
/**
 * ...
 *
 * @overload
 * @returns {TransformMutate}
 *
 * ...
 *
 * @overload
 * @param {Parser | Processor} [destination]
 *   Parser or processor (required).
 * @param {Options | null | undefined} [options]
 *   Configuration (optional).
 * @returns {TransformBridge | TransformMutate}
 *   Transform.
 *
 * ...
 */
```

**Resulting type definitions:**
```ts
export default function remarkRetext(): TransformMutate;
export default function remarkRetext(processor: Processor, options?: Options | null | undefined): TransformBridge;
export default function remarkRetext(parser: Parser, options?: Options | null | undefined): TransformMutate;
export default function remarkRetext(destination?: import("unified").Processor<import("nlcst").Root, undefined, undefined, undefined, undefined> | Parser | undefined, options?: Options | null | undefined): TransformBridge | TransformMutate;
```

This removes the need for `@ts-expect-error` in `test.js` and dependent projects.

<!--do not edit: pr-->
